### PR TITLE
Fix warnings caused by passing custom styles to text props

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,11 +26,11 @@ const propTypes = {
     style: View.propTypes.style,
     selectStyle: View.propTypes.style,
     optionStyle: View.propTypes.style,
-    optionTextStyle: View.propTypes.style,
+    optionTextStyle: Text.propTypes.style,
     sectionStyle: View.propTypes.style,
-    sectionTextStyle: View.propTypes.style,
+    sectionTextStyle: Text.propTypes.style,
     cancelStyle: View.propTypes.style,
-    cancelTextStyle: View.propTypes.style,
+    cancelTextStyle: Text.propTypes.style,
     overlayStyle: View.propTypes.style,
     cancelText: PropTypes.string
 }


### PR DESCRIPTION
This is caused by an improper prop type being set to the text styles. 

Closes #4