### PR TITLE
Expose 'open' as prop for more component control

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ class SampleApp extends Component {
 ## Props
 
 * `data - []` required, array of objects with a unique key and label
+* `open - boolean` optional, boolean that triggers whether or not the dialog is shown
 * `style - object` optional, style definitions for the root element
 * `onChange - function` optional, callback function, when the users has selected an option
 * `initValue - string` optional, text that is initially shown on the button

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ let componentIndex = 0;
 
 const propTypes = {
     data: PropTypes.array,
+    open: PropTypes.bool,
     onChange: PropTypes.func,
     initValue: PropTypes.string,
     style: View.propTypes.style,
@@ -38,6 +39,7 @@ const propTypes = {
 
 const defaultProps = {
     data: [],
+    open: false,
     onChange: ()=> {},
     initValue: 'Select me!',
     style: {},
@@ -82,6 +84,7 @@ export default class ModalPicker extends BaseComponent {
       if (nextProps.initValue != this.props.initValue) {
         this.setState({selected: nextProps.initValue});
       }
+      this.setState({modalVisible: nextProps.open});
     }
 
     onChange(item) {


### PR DESCRIPTION
This modal is awesome, and I love using it! That being said, I found myself wishing I had the ability to treat the modal-picker as a more "controlled" component, where its activation can be triggered programmatically, or through prop-flow further upstream, and not just through manual clicks somewhere in the same class.

This small change supports that. Let me know if you have any suggestions.