### PR TITLE
Added on close

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ class SampleApp extends Component {
                     data={data}
                     initValue="Select something yummy!"
                     onChange={(option)=>{ this.setState({textInputValue:option.label})}}>
-                    
+
                     <TextInput
                         style={{borderWidth:1, borderColor:'#ccc', padding:10, height:30}}
                         editable={false}
                         placeholder="Select something yummy!"
                         value={this.state.textInputValue} />
-                        
+
                 </ModalPicker>
             </View>
         );
@@ -86,6 +86,7 @@ class SampleApp extends Component {
 * `data - []` required, array of objects with a unique key and label
 * `style - object` optional, style definitions for the root element
 * `onChange - function` optional, callback function, when the users has selected an option
+* `onClose - function` optional, callback function, when the modal is closed
 * `initValue - string` optional, text that is initially shown on the button
 * `cancelText - string` optional, text of the cancel button
 * `selectStyle - object` optional, style definitions for the select element (available in default mode only!)

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ let componentIndex = 0;
 const propTypes = {
     data: PropTypes.array,
     onChange: PropTypes.func,
+    onClose: PropTypes.func,
     initValue: PropTypes.string,
     style: View.propTypes.style,
     selectStyle: View.propTypes.style,
@@ -39,6 +40,7 @@ const propTypes = {
 const defaultProps = {
     data: [],
     onChange: ()=> {},
+    onClose: ()=> {},
     initValue: 'Select me!',
     style: {},
     selectStyle: {},
@@ -60,6 +62,7 @@ export default class ModalPicker extends BaseComponent {
 
         this._bind(
             'onChange',
+            'onClose',
             'open',
             'close',
             'renderChildren'
@@ -69,7 +72,8 @@ export default class ModalPicker extends BaseComponent {
             animationType: 'slide',
             modalVisible: false,
             transparent: false,
-            selected: 'please select'
+            selected: 'please select',
+			selectedObject: {},
         };
     }
 
@@ -84,10 +88,21 @@ export default class ModalPicker extends BaseComponent {
       }
     }
 
+	componentWillUpdate(nextProps, nextState){
+		if (nextState.modalVisible != this.state.modalVisible && nextState.modalVisible === false)
+		{
+			this.onClose(nextState.selectedObject);
+		}
+	}
+
     onChange(item) {
         this.props.onChange(item);
-        this.setState({selected: item.label});
+        this.setState({selected: item.label, selectedObject: item});
         this.close();
+    }
+
+    onClose(item) {
+        this.props.onClose(item);
     }
 
     close() {


### PR DESCRIPTION
I have added the ability to pass a function that runs when the modal is hidden. This is usefull for having navigation happen on item select that does not play well with onChange as the navigation is fired before the modal is closed and the reference to the modal could be lost eventhough it is still rendered on the screen. Moving navigation code to onClose solved this problem for me.