### PR TITLE
Changed keyboardShouldPersistTaps from boolean prop to string

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ export default class ModalPicker extends BaseComponent {
         return (
             <View style={[styles.overlayStyle, this.props.overlayStyle]} key={'modalPicker'+(componentIndex++)}>
                 <View style={styles.optionContainer}>
-                    <ScrollView keyboardShouldPersistTaps>
+                    <ScrollView keyboardShouldPersistTaps="always">
                         <View style={{paddingHorizontal:10}}>
                             {options}
                         </View>


### PR DESCRIPTION
Boolean keyboardShouldPersistTaps is deprecated, and is now a string prop with possible values `"always", "handled", "never"`. See discussion in https://github.com/facebook/react-native/pull/10628