### PR TITLE
keyboardShouldPersistTaps=true is deprecated

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ export default class ModalPicker extends BaseComponent {
         return (
             <View style={[styles.overlayStyle, this.props.overlayStyle]} key={'modalPicker'+(componentIndex++)}>
                 <View style={styles.optionContainer}>
-                    <ScrollView keyboardShouldPersistTaps>
+                    <ScrollView keyboardShouldPersistTaps="always">
                         <View style={{paddingHorizontal:10}}>
                             {options}
                         </View>


### PR DESCRIPTION
https://facebook.github.io/react-native/docs/scrollview.html 
keyboardShouldPersistTaps = true is deprecated use always instead. :)