### PR TITLE
Changed View.propTypes.style for ViewPropTypes.style

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ import {
     Text,
     ScrollView,
     TouchableOpacity,
-    Platform
+    Platform,
+    ViewPropTypes
 } from 'react-native';
 
 import styles from './style';
@@ -24,15 +25,15 @@ const propTypes = {
     data: PropTypes.array,
     onChange: PropTypes.func,
     initValue: PropTypes.string,
-    style: View.propTypes.style,
-    selectStyle: View.propTypes.style,
-    optionStyle: View.propTypes.style,
+    style: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
+    selectStyle: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
+    optionStyle: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
     optionTextStyle: Text.propTypes.style,
-    sectionStyle: View.propTypes.style,
+    sectionStyle: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
     sectionTextStyle: Text.propTypes.style,
-    cancelStyle: View.propTypes.style,
+    cancelStyle: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
     cancelTextStyle: Text.propTypes.style,
-    overlayStyle: View.propTypes.style,
+    overlayStyle: ViewPropTypes ? ViewPropTypes.style : View.propTypes.style,
     cancelText: PropTypes.string
 };
 


### PR DESCRIPTION
If this issue is happening with RN 0.49, check for View.propTypes which no longer exists. Use ViewPropTypes instead. 

See commit ending [cd396](https://github.com/facebook/react-native/commit/53905a537a58d028fc5eb1c4e9a8ec967d8cd396)