### PR TITLE
Update deprecations

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ import {
     Text,
     ScrollView,
     TouchableOpacity,
-    Platform
+    Platform,
+    ViewPropTypes
 } from 'react-native';
 
 import styles from './style';
@@ -24,15 +25,15 @@ const propTypes = {
     data: PropTypes.array,
     onChange: PropTypes.func,
     initValue: PropTypes.string,
-    style: View.propTypes.style,
-    selectStyle: View.propTypes.style,
-    optionStyle: View.propTypes.style,
+    style: ViewPropTypes.style,
+    selectStyle: ViewPropTypes.style,
+    optionStyle: ViewPropTypes.style,
     optionTextStyle: Text.propTypes.style,
-    sectionStyle: View.propTypes.style,
+    sectionStyle: ViewPropTypes.style,
     sectionTextStyle: Text.propTypes.style,
-    cancelStyle: View.propTypes.style,
+    cancelStyle: ViewPropTypes.style,
     cancelTextStyle: Text.propTypes.style,
-    overlayStyle: View.propTypes.style,
+    overlayStyle: ViewPropTypes.style,
     cancelText: PropTypes.string
 };
 
@@ -131,7 +132,7 @@ export default class ModalPicker extends BaseComponent {
         return (
             <View style={[styles.overlayStyle, this.props.overlayStyle]} key={'modalPicker'+(componentIndex++)}>
                 <View style={styles.optionContainer}>
-                    <ScrollView keyboardShouldPersistTaps>
+                    <ScrollView keyboardShouldPersistTaps='always'>
                         <View style={{paddingHorizontal:10}}>
                             {options}
                         </View>

--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 'use strict';
 
-import React,{
-    PropTypes
-} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import {
     View,
@@ -70,7 +69,8 @@ export default class ModalPicker extends BaseComponent {
             animationType: 'slide',
             modalVisible: false,
             transparent: false,
-            selected: 'please select'
+            selected: 'please select',
+            initValue: 'Select me!'
         };
     }
 
@@ -79,11 +79,12 @@ export default class ModalPicker extends BaseComponent {
         this.setState({cancelText: this.props.cancelText});
     }
 
-    componentWillReceiveProps(nextProps) {
-      if (nextProps.initValue != this.props.initValue) {
-        this.setState({selected: nextProps.initValue});
-      }
-    }
+    static getDerivedStateFromProps(nextProps, prevState){
+        if(nextProps.initValue !== prevState.initValue){
+          return { selected: nextProps.initValue};
+       }
+       else return null;
+     }
 
     onChange(item) {
         this.props.onChange(item);


### PR DESCRIPTION
https://reactjs.org/blog/2017/04/07/react-v15.5.0.html
In 15.5, instead of accessing PropTypes from the main React object, install the prop-types package and import them from there

https://github.com/facebook/react-native/issues/13999
import ViewPropTypes from 'react-native' package like this:
`import {Text, View, ViewPropTypes} from 'react-native';`

https://reactjs.org/docs/react-component.html
Note: These methods are considered legacy and you should avoid them in new code:
`UNSAFE_componentWillReceiveProps()`
https://reactjs.org/docs/react-component.html#static-getderivedstatefromprops
`static getDerivedStateFromProps(nextProps, prevState)`

https://facebook.github.io/react-native/docs/scrollview#keyboardshouldpersisttaps
`true`, deprecated, use 'always' instead